### PR TITLE
Cleanup

### DIFF
--- a/src/main/java/com/redhat/vertx/search/ConfigMap.java
+++ b/src/main/java/com/redhat/vertx/search/ConfigMap.java
@@ -19,9 +19,13 @@ public class ConfigMap extends AbstractMap<String,String> {
     @Override
     public @NotNull Set<Entry<String, String>> entrySet() {
         Set<Entry<String, String>> set = new HashSet<>();
-        config.getPropertyNames().forEach(prop ->
-            set.add(Map.entry(prop,get(prop)))
-        );
+        config.getPropertyNames().forEach(prop -> {
+                    try {
+                        set.add(Map.entry(prop, get0(prop)));
+                    } catch (NoSuchElementException e) {
+                        // skip it.  Where'd it go?
+                    }
+                });
         return Collections.unmodifiableSet(set);
     }
 
@@ -47,5 +51,4 @@ public class ConfigMap extends AbstractMap<String,String> {
             return false;
         }
     }
-
 }

--- a/src/main/java/com/redhat/vertx/search/step/SolrClient.java
+++ b/src/main/java/com/redhat/vertx/search/step/SolrClient.java
@@ -29,11 +29,6 @@ public class SolrClient extends AbstractStep {
     // wt is not in the above list because it is not specifiable by consumers of this client instance
     private WebClient http;
 
-    @Override
-    public void init(Engine engine, JsonObject config) {
-        super.init(engine, config);
-    }
-
     protected URL generateUrl(JsonObject env) throws StepDependencyNotMetException, URISyntaxException, MalformedURLException {
         String host_url = env.getString("host_url");
         String path = env.getString("path");


### PR DESCRIPTION
This is necessary for compatibility with the Completable Step.init(), but it can stand on its own just as well.  

- remove superfluous init override
- handle vanishing keys in ConfigMap

When I built by maven on the command line, I had a problem with a key present in the set of keys for the config, but not present when attempting to get its value from the config to construct a Map.Entry.  Such keys are now tacitly dropped from the entrySet.